### PR TITLE
refactor tests

### DIFF
--- a/tests/api/health_check.rs
+++ b/tests/api/health_check.rs
@@ -1,9 +1,9 @@
-use crate::helpers::spawn_app;
+use crate::helpers::TestApp;
 
 #[tokio::test]
 async fn health_check_works() {
     // Arrange
-    let app = spawn_app().await;
+    let app = TestApp::new().await;
     let client = reqwest::Client::new();
 
     // Act

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,2 +1,4 @@
 mod health_check;
 mod helpers;
+mod services;
+mod wrappers;

--- a/tests/api/services.rs
+++ b/tests/api/services.rs
@@ -1,0 +1,52 @@
+use std::ops::Deref;
+
+use sqlx::{Connection, Executor, PgConnection, PgPool};
+
+use super::wrappers::TestConfiguration;
+
+/// A database to be used for testing.
+pub struct TestDatabase(PgPool);
+
+impl TestDatabase {
+    /// Create a new TestDatabase from the provided DatabaseSettings.
+    ///
+    /// Creating a test database implies:
+    /// 1. Creating a new database in Postgres with a random UUIDv4 as its name.
+    /// 2. Running the migrations against the newly created database.
+    pub async fn new(config: &TestConfiguration) -> Self {
+        // Acquire a connection to Postgres
+        let mut connection = PgConnection::connect_with(&config.without_db())
+            .await
+            .expect("failed to connect to Postgres");
+
+        // Create database
+        connection
+            .execute(&*format!(r#"CREATE DATABASE "{}";"#, config.db_name()))
+            .await
+            .expect("failed to create database");
+
+        // Migrate database
+        let connection_pool = PgPool::connect_with(config.with_db())
+            .await
+            .expect("failed to connect to Postgres");
+
+        sqlx::migrate!("./migrations")
+            .run(&connection_pool)
+            .await
+            .expect("failed to migrate the database");
+
+        TestDatabase(connection_pool)
+    }
+}
+
+impl Deref for TestDatabase {
+    type Target = PgPool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// TODO: Se puede implementar Drop para que haga DROP DATABASE {database.name}
+
+// TODO: Implementar servicio de Redis

--- a/tests/api/wrappers.rs
+++ b/tests/api/wrappers.rs
@@ -1,0 +1,73 @@
+use std::convert::From;
+use std::ops::Deref;
+
+use sqlx::postgres::PgConnectOptions;
+use uuid::Uuid;
+
+use chocoapi::configuration::Settings;
+use chocoapi::startup::Application;
+
+pub struct TestAPI(Application);
+
+impl TestAPI {
+    pub async fn new(configuration: TestConfiguration) -> Self {
+        let application = Application::build(configuration.into())
+            .await
+            .expect("failed to build application");
+        TestAPI(application)
+    }
+}
+
+impl Deref for TestAPI {
+    type Target = Application;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<TestAPI> for Application {
+    fn from(w: TestAPI) -> Application {
+        w.0
+    }
+}
+
+#[derive(Clone)]
+pub struct TestConfiguration(Settings);
+
+impl TestConfiguration {
+    pub fn new(mut config: Settings) -> Self {
+        config.application.port = 0;
+        config.database.host = "localhost".to_string();
+        config.database.database_name = Uuid::new_v4().to_string();
+        TestConfiguration(config)
+    }
+}
+
+impl TestConfiguration {
+    pub fn db_name(&self) -> &str {
+        &self.database.database_name
+    }
+
+    pub fn with_db(&self) -> PgConnectOptions {
+        self.database.with_db()
+    }
+
+    pub fn without_db(&self) -> PgConnectOptions {
+        self.database.without_db()
+    }
+}
+
+impl Deref for TestConfiguration {
+    type Target = Settings;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<TestConfiguration> for Settings {
+    fn from(w: TestConfiguration) -> Settings {
+        w.0
+    }
+}


### PR DESCRIPTION
The changes were mostly at the type level and system design. These changes:

1. Make sure it is not possible to run a test with an unprepared database.
2. Make it easier to add external dependencies as test services in the future (redis or a mock mail service for example)

Please enjoy.